### PR TITLE
Forcing tox to install locally bundled wheels

### DIFF
--- a/src/azure_devops_artifacts_helpers/tox_venv.py
+++ b/src/azure_devops_artifacts_helpers/tox_venv.py
@@ -4,6 +4,8 @@ from typing import Any
 
 from packaging.requirements import Requirement
 
+from azure_devops_artifacts_helpers.seed import EXT_DIR
+
 try:
     import tox
 except (ImportError, ModuleNotFoundError):  # pragma: no cover
@@ -26,7 +28,11 @@ if tox:
         @impl
         def tox_on_install(tox_env: ToxEnv, arguments: Any, section: str, of_type: str) -> None:  # noqa: U100
             """Called before executing an installation command to install artifacts keyring."""
-            tox_env.installer.install([Requirement('artifacts-keyring')], tox_env.__class__.__name__, 'pre_deps')
+            # To force install from the bundled wheels, we use the following pip flags:
+            #    -f EXT_DIR --no-index
+            # This makes pip look in the bundled wheel dir, and not use the index
+            tox_env.installer._execute_installer(['artifacts-keyring', '-f', EXT_DIR, '--no-index'], 'pre_deps')
+
 
     else:
         from tox.venv import cleanup_for_venv, _SKIP_VENV_CREATION, reporter

--- a/src/azure_devops_artifacts_helpers/tox_venv.py
+++ b/src/azure_devops_artifacts_helpers/tox_venv.py
@@ -2,8 +2,6 @@
 import sys
 from typing import Any
 
-from packaging.requirements import Requirement
-
 from azure_devops_artifacts_helpers.seed import EXT_DIR
 
 try:
@@ -32,7 +30,6 @@ if tox:
             #    -f EXT_DIR --no-index
             # This makes pip look in the bundled wheel dir, and not use the index
             tox_env.installer._execute_installer(['artifacts-keyring', '-f', EXT_DIR, '--no-index'], 'pre_deps')
-
 
     else:
         from tox.venv import cleanup_for_venv, _SKIP_VENV_CREATION, reporter

--- a/tests/functional/tox/test_tox_init.py
+++ b/tests/functional/tox/test_tox_init.py
@@ -4,6 +4,12 @@ import subprocess
 import sys
 import unittest
 
+import tox
+try:
+    tox_v4 = tox.version.version_tuple[0] > 3
+except AttributeError:
+    tox_v4 = False  # Version 3
+
 
 TOX_INI = 'tox.ini'
 
@@ -39,10 +45,11 @@ commands =
         self.assertIn('artifacts-keyring', tox_output)
         self.assertIn('requests', tox_output)
         self.assertIn('keyring', tox_output)
-        # Test local install
-        self.assertIn('python -I -m pip install artifacts-keyring -f', tox_output)
-        self.assertIn('Looking in links', tox_output)
-        self.assertNotIn('Downloading artifacts-keyring', tox_output)
+        if tox_v4:
+            # Test local install
+            self.assertIn('python -I -m pip install artifacts-keyring -f', tox_output)
+            self.assertIn('Looking in links', tox_output)
+            self.assertNotIn('Downloading artifacts-keyring', tox_output)
         print(tox_output)
 
     def test_tox_extra_args(self):
@@ -52,8 +59,9 @@ commands =
         self.assertIn('artifacts-keyring', tox_output)
         self.assertIn('requests', tox_output)
         self.assertIn('keyring', tox_output)
-        # Test local install
-        self.assertIn('python -I -m pip install artifacts-keyring -f', tox_output)
-        self.assertIn('Looking in links', tox_output)
-        self.assertNotIn('Downloading artifacts-keyring', tox_output)
+        if tox_v4:
+            # Test local install
+            self.assertIn('python -I -m pip install artifacts-keyring -f', tox_output)
+            self.assertIn('Looking in links', tox_output)
+            self.assertNotIn('Downloading artifacts-keyring', tox_output)
         print(tox_output)

--- a/tests/functional/tox/test_tox_init.py
+++ b/tests/functional/tox/test_tox_init.py
@@ -39,6 +39,11 @@ commands =
         self.assertIn('artifacts-keyring', tox_output)
         self.assertIn('requests', tox_output)
         self.assertIn('keyring', tox_output)
+        # Test local install
+        self.assertIn('python -I -m pip install artifacts-keyring -f', tox_output)
+        self.assertIn('Looking in links', tox_output)
+        self.assertNotIn('Downloading artifacts-keyring', tox_output)
+        print(tox_output)
 
     def test_tox_extra_args(self):
         with open(str(Path(self.td.name)/TOX_INI), 'w') as f:
@@ -47,3 +52,8 @@ commands =
         self.assertIn('artifacts-keyring', tox_output)
         self.assertIn('requests', tox_output)
         self.assertIn('keyring', tox_output)
+        # Test local install
+        self.assertIn('python -I -m pip install artifacts-keyring -f', tox_output)
+        self.assertIn('Looking in links', tox_output)
+        self.assertNotIn('Downloading artifacts-keyring', tox_output)
+        print(tox_output)


### PR DESCRIPTION
Avoiding chicken and egg with tox env config and pip index authentication.

Closes #69 