### PR TITLE
Fix pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -322,7 +322,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags')
 
   publish-docs:
-    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')  && !(contains(github.ref, 'gh-pages') || contains(github.ref, 'docs')) ) || github.event_name == 'release'
+    # Only do this on the tagged build, not the release
+    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')  && !(contains(github.ref, 'gh-pages') || contains(github.ref, 'docs')) )
     name: Publish Docs
     runs-on: ubuntu-latest
     needs:
@@ -340,7 +341,7 @@ jobs:
           tag_name=$(echo ${{github.ref}} | cut -d/ -f3)
           echo "::set-output name=tag_name::$tag_name"
       - name: Check Tag doesn't exist
-        id: get_version
+        id: check_tag
         run: |
           if git show-ref --tags docs-${{ steps.get_version.outputs.tag_name }} --quiet; then
             echo "::set-output name=tag_exists::true"
@@ -349,7 +350,7 @@ jobs:
           fi
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: steps.get_version.outputs.tag_exists == false
+        if: steps.check_tag.outputs.tag_exists == false
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/html

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -339,8 +339,17 @@ jobs:
         run: |
           tag_name=$(echo ${{github.ref}} | cut -d/ -f3)
           echo "::set-output name=tag_name::$tag_name"
+      - name: Check Tag doesn't exist
+        id: get_version
+        run: |
+          if git show-ref --tags docs-${{ steps.get_version.outputs.tag_name }} --quiet; then
+            echo "::set-output name=tag_exists::true"
+          else
+            echo "::set-output name=tag_exists::false"
+          fi
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
+        if: steps.get_version.outputs.tag_exists == false
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/html

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -339,14 +339,15 @@ jobs:
         id: get_version
         run: |
           tag_name=$(echo ${{github.ref}} | cut -d/ -f3)
-          echo "::set-output name=tag_name::$tag_name"
+          echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
       - name: Check Tag doesn't exist
         id: check_tag
         run: |
           if git show-ref --tags docs-${{ steps.get_version.outputs.tag_name }} --quiet; then
             echo "::set-output name=tag_exists::true"
+            echo "tag_exists=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=tag_exists::false"
+            echo "tag_exists=false" >> $GITHUB_OUTPUT
           fi
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Fixing deployment pipeline to avoid issue with tag and release triggering docs deployment
Fixing ``::set-output`` deprecation (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)