### PR TITLE
Adding fix for token store in .doctrees

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -240,6 +240,7 @@ jobs:
           name: docs
           path: |
             docs/html/*
+            !docs/html/.doctrees/*
 
   test-build:
     if: github.event_name == 'pull_request' && contains(github.base_ref, 'main') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || github.event_name == 'release'


### PR DESCRIPTION
Session GITHUB_TOKEN was stored in this file - not a security risk, but better to stop committing them