### PR TITLE
Removing pip-compile usage due to inconsistencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ overrides = [
   { module = [
     "virtualenv.*",
     "tox.*",
+    "importlib_metadata.*",
     "azure_devops_artifacts_helpers._version"
   ], ignore_missing_imports = true },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ dev-docs = [
     "sphinx_github_changelog"
 ]
 dev-populate = [
+    "packaging",
     "click"
 ]
 dev-build = [

--- a/tools/generate-pipenv.py
+++ b/tools/generate-pipenv.py
@@ -1,0 +1,49 @@
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import List
+
+print(sys.version_info, sys.executable)
+
+
+def run(input_file:str) -> None:
+    _prep()
+    _generate_pipfile(_compile(input_file))
+
+def _prep() -> None:
+    if sys.version_info.minor < 11 and sys.version_info.major >= 3:
+        print('Installing tomli')
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'tomli'])
+
+def _compile(input_file: str) -> str:
+    if sys.version_info.minor >= 11 and sys.version_info.major >= 3:
+        import tomllib as toml
+    else:
+        import tomli as toml  # type: ignore
+    output_file = 'requirements.txt'
+    with open(input_file) as f:
+        config = toml.loads(f.read())
+    dependencies = config['project']['dependencies']
+    for extra in config['project']['optional-dependencies']:
+        dependencies += config['project']['optional-dependencies'][extra]
+    with open(output_file, 'w') as f:
+        f.write('\n'.join(dependencies))
+    return output_file
+
+def _generate_pipfile(requirements_file: str) -> None:
+    if Path('Pipfile').exists():
+        os.remove('Pipfile')
+    if Path('Pipfile.lock').exists():
+        os.remove('Pipfile.lock')
+    args = [sys.executable, '-m', 'pipenv', 'lock']
+    subprocess.check_call(args)
+    os.remove(requirements_file)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--input-file', default='pyproject.toml')
+    args = parser.parse_args()
+    # Pass un expected args to the install step
+    run(args.input_file)

--- a/tools/populate-wheels.py
+++ b/tools/populate-wheels.py
@@ -6,7 +6,7 @@ import sys
 from typing import List
 
 import click
-from packaging.version import Version
+from packaging.version import Version  # type: ignore
 
 if sys.version_info.minor >= 11 and sys.version_info.major >= 3:
     import tomllib as toml

--- a/tox.ini
+++ b/tox.ini
@@ -6,25 +6,24 @@ requires =
 
 [testenv]
 # pip compile extras and then install
-install_command = python -I tools/tox-install.py --extras {packages} --env-name {envname} --input-file pyproject.toml {opts}
+install_command = python -I tools/tox-install.py {packages} --env-name {envname} --input-file pyproject.toml {opts}
 
 [testenv:lint]
-skip_install=True
 allowlist_externals=rm
 deps =
     ; pyproject.toml extra
-    dev-lint
+    .[dev-lint]
 
 commands =
     flake8 src/
-    pipenv lock
+    python tools/generate-pipenv.py
     pipenv check
     mypy src/ tools/
 
 [testenv:docs]
 deps =
     ; pyproject.toml extra
-    dev-docs
+    .[dev-docs]
 commands =
     python -m sphinx -b html -a {toxinidir}/docs/source {toxinidir}/docs/html
 
@@ -34,7 +33,7 @@ passenv =
 [testenv:build]
 deps =
     ; pyproject.toml extra
-    dev-build
+    .[dev-build]
 commands =
     python build
     ; builds wheel and sdist
@@ -42,8 +41,8 @@ commands =
 [testenv:test-{v3,v4}]
 deps=
     ; pyproject.toml extra
-    v4: dev-test-v4
-    v3: dev-test-v3
+    v4: .[dev-test-v4]
+    v3: .[dev-test-v3]
 commands =
     python -m pip freeze
     python -m pytest {posargs: -rs tests/ --log-level=WARNING --cov=azure_devops_artifacts_helpers --cov-report xml:{toxinidir}/reports/{envname}-coverage.xml --junitxml={toxinidir}/reports/{envname}-test.xml}
@@ -52,9 +51,9 @@ commands =
 skip_install = True
 deps =
     ; pyproject.toml extra
-    dev-populate
+    .[dev-populate]
 commands =
-    python tools/populate_wheels.py {posargs}
+    python tools/populate-wheels.py {posargs}
 
 [testenv:develop]
 skip_install = True
@@ -66,9 +65,9 @@ commands =
     tox -e populate
 deps =
     ; pyproject.toml extras
-    dev
-    dev-lint
-    dev-test-v4
-    dev-build
-    dev-docs
-    dev-populate
+    .[dev]
+    .[dev-lint]
+    .[dev-test-v4]
+    .[dev-build]
+    .[dev-docs]
+    .[dev-populate]


### PR DESCRIPTION
``pip-compile`` seems to be having non-deterministic behaviour when resolving packages - we don't actually need that level of resolution for that stage, so switching to parsing the ``pyproject.toml`` instead
Also handling creating a requirements file for ``pipenv`` check